### PR TITLE
fix a hashcode & equals contract

### DIFF
--- a/src/main/java/com/felixseifert/swedisheventplanners/backend/model/AbstractEntity.java
+++ b/src/main/java/com/felixseifert/swedisheventplanners/backend/model/AbstractEntity.java
@@ -1,11 +1,11 @@
 package com.felixseifert.swedisheventplanners.backend.model;
 
-import lombok.Getter;
-import lombok.Setter;
-
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.MappedSuperclass;
+
+import lombok.Getter;
+import lombok.Setter;
 
 @MappedSuperclass
 @Getter
@@ -16,16 +16,4 @@ public abstract class AbstractEntity {
     @GeneratedValue
     private Long id;
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        AbstractEntity that = (AbstractEntity) o;
-        return id.equals(that.id);
-    }
-
-    @Override
-    public int hashCode() {
-        return 11;
-    }
 }

--- a/src/main/java/com/felixseifert/swedisheventplanners/backend/model/Client.java
+++ b/src/main/java/com/felixseifert/swedisheventplanners/backend/model/Client.java
@@ -1,11 +1,12 @@
 package com.felixseifert.swedisheventplanners.backend.model;
 
-import lombok.Getter;
-import lombok.Setter;
-
+import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Table;
+
+import lombok.Getter;
+import lombok.Setter;
 
 @Entity
 @Table(name = "clients")
@@ -19,15 +20,22 @@ public class Client extends AbstractEntity {
     private String contactDetails;
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        return super.equals(o);
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof Client)) {
+            return false;
+        }
+        Client client = (Client) obj;
+        return Objects.equals(this.getId(), client.getId()) &&
+                Objects.equals(name, client.name) &&
+                Objects.equals(contactDetails, client.contactDetails);
     }
 
     @Override
     public int hashCode() {
-        return 22;
+        return Objects.hash(this.getId(), name, contactDetails);
     }
 
     @Override

--- a/src/main/java/com/felixseifert/swedisheventplanners/backend/model/Employee.java
+++ b/src/main/java/com/felixseifert/swedisheventplanners/backend/model/Employee.java
@@ -1,14 +1,20 @@
 package com.felixseifert.swedisheventplanners.backend.model;
 
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import javax.persistence.CollectionTable;
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+
 import com.felixseifert.swedisheventplanners.backend.model.enums.Role;
 import com.felixseifert.swedisheventplanners.backend.model.enums.RoleConverter;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-
-import javax.persistence.*;
-import java.util.HashSet;
-import java.util.Set;
 
 @Entity
 @Getter
@@ -31,16 +37,23 @@ public class Employee extends AbstractEntity {
     public void removeRole(Role role) {
         roles.remove(role);
     }
-    
+
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        return super.equals(o);
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof Employee)) {
+            return false;
+        }
+        Employee employee = (Employee) obj;
+        return Objects.equals(this.getId(), employee.getId()) &&
+                Objects.equals(name, employee.name) &&
+                Objects.equals(roles, employee.roles);
     }
 
     @Override
     public int hashCode() {
-        return 13;
+        return Objects.hash(this.getId(), name, roles);
     }
 }

--- a/src/main/java/com/felixseifert/swedisheventplanners/backend/model/NewRequest.java
+++ b/src/main/java/com/felixseifert/swedisheventplanners/backend/model/NewRequest.java
@@ -1,13 +1,26 @@
 package com.felixseifert.swedisheventplanners.backend.model;
 
-import com.felixseifert.swedisheventplanners.backend.model.enums.*;
-import lombok.Getter;
-import lombok.Setter;
-
-import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
+import javax.persistence.CollectionTable;
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import com.felixseifert.swedisheventplanners.backend.model.enums.EventType;
+import com.felixseifert.swedisheventplanners.backend.model.enums.EventTypeConverter;
+import com.felixseifert.swedisheventplanners.backend.model.enums.Preference;
+import com.felixseifert.swedisheventplanners.backend.model.enums.PreferencesConverter;
+import com.felixseifert.swedisheventplanners.backend.model.enums.RequestStatus;
+import lombok.Getter;
+import lombok.Setter;
 
 @Entity
 @Table(name = "new_requests")
@@ -60,15 +73,32 @@ public class NewRequest extends AbstractEntity {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        return super.equals(o);
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof NewRequest)) {
+            return false;
+        }
+        NewRequest request = (NewRequest) obj;
+        return Objects.equals(this.getId(), request.getId()) &&
+                Objects.equals(recordNumber, request.recordNumber) &&
+                Objects.equals(client, request.client) &&
+                eventType == request.eventType &&
+                Objects.equals(from, request.from) &&
+                Objects.equals(to, request.to) &&
+                Objects.equals(expectedNumberOfAttendees, request.expectedNumberOfAttendees) &&
+                Objects.equals(expectedBudget, request.expectedBudget) &&
+                Objects.equals(preferences, request.preferences) &&
+                requestStatus == request.requestStatus &&
+                Objects.equals(meetingDate, request.meetingDate);
     }
 
     @Override
     public int hashCode() {
-        return 33;
+        return Objects.hash(this.getId(), recordNumber, client,
+                eventType, from, to, expectedNumberOfAttendees,
+                expectedBudget, preferences, requestStatus, meetingDate);
     }
 
     @Override

--- a/src/main/java/com/felixseifert/swedisheventplanners/backend/model/Proposal.java
+++ b/src/main/java/com/felixseifert/swedisheventplanners/backend/model/Proposal.java
@@ -1,5 +1,16 @@
 package com.felixseifert.swedisheventplanners.backend.model;
 
+import java.time.LocalDateTime;
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+
 import com.felixseifert.swedisheventplanners.backend.model.enums.EventType;
 import com.felixseifert.swedisheventplanners.backend.model.enums.EventTypeConverter;
 import com.felixseifert.swedisheventplanners.backend.model.enums.ProposalStatus;
@@ -7,14 +18,11 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.persistence.*;
-import java.time.LocalDateTime;
-
 @Entity
 @Table(name = "proposals")
 @Getter
 @Setter
-public class Proposal extends AbstractEntity{
+public class Proposal extends AbstractEntity {
 
     @Column(nullable = false, length = 10)
     private String recordNumber;
@@ -64,11 +72,11 @@ public class Proposal extends AbstractEntity{
     }
 
     public ProposalStatus getProposalStatus() {
-        if(ProposalStatus.INITIATED.equals(productionProposalStatus)
+        if (ProposalStatus.INITIATED.equals(productionProposalStatus)
                 && ProposalStatus.INITIATED.equals(serviceProposalStatus)) {
             return ProposalStatus.INITIATED;
         }
-        if(ProposalStatus.CLOSED.equals(productionProposalStatus)
+        if (ProposalStatus.CLOSED.equals(productionProposalStatus)
                 && ProposalStatus.CLOSED.equals(serviceProposalStatus)) {
             return ProposalStatus.CLOSED;
         }
@@ -76,15 +84,39 @@ public class Proposal extends AbstractEntity{
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        return super.equals(o);
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof Proposal)) {
+            return false;
+        }
+        Proposal proposal = (Proposal) obj;
+        return Objects.equals(this.getId(), proposal.getId()) &&
+                Objects.equals(recordNumber, proposal.recordNumber) &&
+                Objects.equals(client, proposal.client) &&
+                eventType == proposal.eventType &&
+                Objects.equals(from, proposal.from) &&
+                Objects.equals(to, proposal.to) &&
+                Objects.equals(expectedNumberOfAttendees, proposal.expectedNumberOfAttendees) &&
+                Objects.equals(expectedBudget, proposal.expectedBudget) &&
+                Objects.equals(decorations, proposal.decorations) &&
+                Objects.equals(filmingPhotos, proposal.filmingPhotos) &&
+                Objects.equals(postersArtWork, proposal.postersArtWork) &&
+                Objects.equals(foodDrinks, proposal.foodDrinks) &&
+                Objects.equals(music, proposal.music) &&
+                Objects.equals(computerRelatedIssues, proposal.computerRelatedIssues) &&
+                proposalStatus == proposal.proposalStatus &&
+                productionProposalStatus == proposal.productionProposalStatus &&
+                serviceProposalStatus == proposal.serviceProposalStatus;
     }
 
     @Override
     public int hashCode() {
-        return 44;
+        return Objects.hash(this.getId(), recordNumber, client, eventType, from, to,
+                expectedNumberOfAttendees, expectedBudget, decorations, filmingPhotos,
+                postersArtWork, foodDrinks, music, computerRelatedIssues,
+                proposalStatus, productionProposalStatus, serviceProposalStatus);
     }
 
     @Override


### PR DESCRIPTION
Due to the fact that the previous implementation might lead to the hashcode collision while used within Map collections it's required to follow the proper equals and hashcode contract. All the fields of underlying classes must be included in the hashcode and equals generation.

Having the previous implementation it's fairly possible that several instances of the "Client" or any other entity would be included in the Map as a key which would lead to the hashcode collision and those would be put into the same bucket, therefore, leading to lower performance. Same as if it'd be required to get a Set of elements from the database. It would fail as well since Sets don't allow duplicate values.

See: https://www.baeldung.com/java-equals-hashcode-contracts